### PR TITLE
Add comment and reformat bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **Deployment:**
 <!--- To get the versions via command line `docker version` and `docker-compose version` -->
 * Docker Version:
-* Docker Compose Version:
+* Docker Compose Version (if applicable):
 * Deployment Type: Local, Cloud Service (e.g. Render.com), Other Server Deploy
 * Deployment Details: If not local deploy, detailed description of deployment setup.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,9 +24,11 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Deployment:**
-Docker Version:
-Deployment Type: Local, Cloud Service (e.g. Render.com), Other Server Deploy
-Deployment Details: If not local deploy, detailed description of deployment setup.
+<!--- To get the versions via command line `docker version` and `docker-compose version` -->
+* Docker Version:
+* Docker Compose Version:
+* Deployment Type: Local, Cloud Service (e.g. Render.com), Other Server Deploy
+* Deployment Details: If not local deploy, detailed description of deployment setup.
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
# Changes

- Add comment on how to get the docker and docker-compose version
- Add a spot for the docker compose version
- Turn the deployment details in to a list for cleanliness due to the way markdown works
  - If they are not a list it will try to print them all on one line unless there is a blank line between them when rendered from markdown->html.