### PR TITLE
Set protocol to https if the 'X-Forwarded-Proto' header is set

### DIFF
--- a/tau/config/common.py
+++ b/tau/config/common.py
@@ -70,6 +70,7 @@ class Common(Configuration):  # pylint: disable=no-init
     SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
     WSGI_APPLICATION = 'tau.wsgi.application'
     ASGI_APPLICATION = 'tau.asgi.application'
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
     REDIS_ENDPOINT = os.environ.get('REDIS_ENDPOINT','redis:6379')
     REDIS_PW = os.environ.get('REDIS_PW','')


### PR DESCRIPTION
Fixes the Django Rest Framework response to reference HTTPS instead of HTTP

## Description
When making requests to the API, if there are paginated responses, the pagination would reference http instead of https even on an https server behind a reverse proxy.  This does require that the `X-Forwarded-Proto` header is set in the nginx config (or whatever reverse proxy others are using).

## Motivation and Context
Makes handling pagination simpler for users that have SSL setup via a reverse proxy.

## How Has This Been Tested?
Manual using my dev server.  

### Before change (production server instead of before change in dev)
<img width="582" alt="Screen Shot 2021-06-26 at 12 01 15 AM" src="https://user-images.githubusercontent.com/839261/123505167-5f350e00-d612-11eb-93ce-b9f42685214a.png">



### After change
<img width="567" alt="Screen Shot 2021-06-26 at 12 01 24 AM" src="https://user-images.githubusercontent.com/839261/123505066-d1592300-d611-11eb-8857-e5f8e409ce7f.png">
