### PR TITLE
Twitch api call debugging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       USE_NGROK: ${USE_NGROK:-True}
       PORT: ${PORT:-8000}
       TWITCH_WEBHOOK_SECRET: ${TWITCH_WEBHOOK_SECRET}
+      DEBUG_TWITCH_CALLS: ${DEBUG_TWITCH_CALLS:-False}
     depends_on:
       - db
       - redis

--- a/tau/config/common.py
+++ b/tau/config/common.py
@@ -27,6 +27,8 @@ class Common(Configuration):  # pylint: disable=no-init
     else:
         LOCAL_URL = BASE_URL
 
+    DEBUG_TWITCH_CALLS = os.environ.get("DEBUG_TWITCH_CALLS", "False").lower() == "true"
+
     INSTALLED_APPS = (
         'django.contrib.admin',
         'django.contrib.auth',

--- a/tau/config/local.py
+++ b/tau/config/local.py
@@ -4,7 +4,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 class Local(Common):
-    DEBUG = os.environ.get('DEBUG', True)
+    DEBUG = os.environ.get('DEBUG', "True").lower == "true"
 
     # Testing
     INSTALLED_APPS = Common.INSTALLED_APPS

--- a/tau/config/production.py
+++ b/tau/config/production.py
@@ -5,6 +5,8 @@ from .common import Common
 class Production(Common):
     INSTALLED_APPS = Common.INSTALLED_APPS
 
+    DEBUG = os.environ.get('DEBUG', "False").lower() == "true"
+
     ins = list(Common.MIDDLEWARE).index('django.middleware.security.SecurityMiddleware')
     if ins:
         MIDDLEWARE=list(Common.MIDDLEWARE)

--- a/tau/core/views.py
+++ b/tau/core/views.py
@@ -18,6 +18,7 @@ import constance.settings
 from tau.twitch.models import TwitchAPIScope
 from tau.users.models import User
 from .forms import ChannelNameForm, FirstRunForm
+from  .utils import log_request
 from tau.twitch.models import TwitchHelixEndpoint
 
 @api_view(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])

--- a/tau/core/views.py
+++ b/tau/core/views.py
@@ -79,6 +79,8 @@ def helix_view(request, helix_path=None):
             headers=headers
         )
     try:
+        if(settings.DEBUG_TWITCH_CALLS):
+            log_request(data)
         stream_data = data.json()
     except ValueError:
         stream_data = None
@@ -183,6 +185,8 @@ def process_twitch_callback_view(request):
         'redirect_uri': f'{settings.BASE_URL}/twitch-callback/'
     })
     response_data = auth_r.json()
+    if(settings.DEBUG_TWITCH_CALLS):
+        log_request(auth_r)
     config.TWITCH_ACCESS_TOKEN = response_data['access_token']
     config.TWITCH_REFRESH_TOKEN = response_data['refresh_token']
 
@@ -193,6 +197,8 @@ def process_twitch_callback_view(request):
         'grant_type': 'client_credentials',
         'scope': scope
     })
+    if(settings.DEBUG_TWITCH_CALLS):
+        log_request(app_auth_r)
     app_auth_data = app_auth_r.json()
     config.TWITCH_APP_ACCESS_TOKEN = app_auth_data['access_token']
     config.SCOPE_UPDATED_NEEDED = False
@@ -201,6 +207,8 @@ def process_twitch_callback_view(request):
         'Client-Id': client_id
     }
     user_r = requests.get('https://api.twitch.tv/helix/users', headers=headers)
+    if(settings.DEBUG_TWITCH_CALLS):
+        log_request(user_r)
     user_data = user_r.json()
     channel_id = user_data['data'][0]['id']
     config.CHANNEL_ID = channel_id


### PR DESCRIPTION
Adds Twitch REST API call debugging.

## Description
When TAU makes requests from the Twitch Helix APIs, if the request fails it currently fails silently.  This PR provides a new environment variable, `DEBUG_TWITCH_CALLS` which logs the call, response code, and response body for all calls to the Helix API, in order to debug, for example, failed tokens.

## Motivation and Context
Makes debugging Twitch Helix API calls possible.

## How Has This Been Tested?
Manually using my dev server.  