### PR TITLE
Add example for subscribe event as well

### DIFF
--- a/docs/new_tau_changes.md
+++ b/docs/new_tau_changes.md
@@ -6,6 +6,7 @@ A recent release of TAU created some breaking changes from the original version 
 - old: `follow`, new: `channel-follow`
 - old: `point-redemption`, new: `channel-channel_points_custom_reward_redemption-add`
 - old: `cheer`, new: `channel-cheer`
+- old: `subscribe`, new: `channel-subscribe`
 - old: `raid`, new: `channel-raid`
 - old: `hype-train-progress`, new: `channel-hype_train-progress`
 - old: `hype-train-begin`, new: `channel-hype_train-begin`


### PR DESCRIPTION
I wasn't sure if that event changed or not since it wasn't originally listed but once I tested the event I saw that changed too. This adds it to the list to avoid any confusion.