### PR TITLE
Implements webhook monitor/reset page.

### DIFF
--- a/tau-dashboard/src/components/layout/SideBar.vue
+++ b/tau-dashboard/src/components/layout/SideBar.vue
@@ -50,6 +50,11 @@ export default defineComponent({
         icon: 'pi pi-user',
         routeTo: '/dashboard/user',
       },
+      {
+        label: 'Webhooks',
+        icon: 'pi pi-sitemap',
+        routeTo: '/dashboard/webhook-monitor',
+      },
     ]);
     return {
       items,

--- a/tau-dashboard/src/components/views/WebhookMonitor.vue
+++ b/tau-dashboard/src/components/views/WebhookMonitor.vue
@@ -1,0 +1,80 @@
+<template>
+  <h1>Webhook Monitor</h1>
+  <Panel class="dark-header" header="Registered Twitch Webhooks">
+    <DataTable :value="webhooks" stripedRows>
+      <Column field="type" header="Type"></Column>
+      <Column field="status" header="Status"></Column>
+      <Column field="transport" header="Local">
+        <template #body="{ data }">
+          <i
+            class="pi"
+            :class="
+              isLocal(data.transport.callback)
+                ? ['pi-check', 'green']
+                : ['pi-times', 'red']
+            "
+          ></i>
+        </template>
+      </Column>
+    </DataTable>
+    <Button @click="resetWebhooks('all')" class="mr-2 mt-2">All</Button>
+    <Button @click="resetWebhooks('remote')" class="mr-2 mt-2">Remote</Button>
+    <Button @click="resetWebhooks('broken')" class="mr-2 mt-2">Broken</Button>
+    <!-- <Button @click="updateSettings()">Update Settings</Button> -->
+  </Panel>
+</template>
+
+<script lang="ts">
+import { defineComponent, onMounted, ref } from 'vue';
+
+import api$ from '@/services/tau-apis';
+import {
+  EventsubSubscriptionResponse,
+  EventsubSubscription,
+} from '@/models/twitch-helix-endpoint';
+
+export default defineComponent({
+  setup() {
+    const webhooks = ref<EventsubSubscription[]>([]);
+    const publicUrl = ref('');
+
+    onMounted(async () => {
+      const publicUrlData = await api$.tau.get('public_url');
+      publicUrl.value = publicUrlData.public_url.split('/')[2];
+      console.log(publicUrl.value);
+      const data = await api$.helix.get<EventsubSubscriptionResponse>(
+        'eventsub/subscriptions',
+      );
+      console.log(data.data);
+      webhooks.value = data.data;
+    });
+
+    const isLocal = function (url: string) {
+      const baseUrl = url.split('/')[2];
+      return baseUrl === publicUrl.value;
+    };
+
+    const resetWebhooks = async function (resetType: string) {
+      const payload = {
+        type: resetType,
+      };
+      const resp = await api$.tau.post('reset-webhooks', payload);
+    };
+
+    return {
+      webhooks,
+      resetWebhooks,
+      isLocal,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.green {
+  color: var(--green-400);
+}
+.red {
+  color: var(--pink-600);
+}
+</style>

--- a/tau-dashboard/src/models/twitch-helix-endpoint.ts
+++ b/tau-dashboard/src/models/twitch-helix-endpoint.ts
@@ -7,3 +7,38 @@ export interface TwitchHelixEndpoint {
   scope: string;
   token_type: string;
 }
+
+export interface EventsubSubscriptionResponse {
+  total: number;
+  data: EventsubSubscription[];
+  maxTotalCost: number;
+  totalCost: number;
+  pagination: Pagination;
+}
+
+export interface Pagination {
+  cursor?: string;
+}
+
+export interface EventsubSubscription {
+  id: string;
+  status: string;
+  type: string;
+  version: string;
+  condition: Condition;
+  createdAt: Date;
+  transport: Transport;
+  cost: number;
+}
+
+export interface Condition {
+  broadcasterUserId?: string;
+  rewardId?: string;
+  fromBroadcasterUserId?: string;
+  toBroadcasterUserId?: string;
+}
+
+export interface Transport {
+  method: string;
+  callback: string;
+}

--- a/tau-dashboard/src/router/index.ts
+++ b/tau-dashboard/src/router/index.ts
@@ -45,6 +45,11 @@ const routes: Array<RouteRecordRaw> = [
         name: 'User',
         component: () => import('../components/views/User.vue'),
       },
+      {
+        path: 'webhook-monitor',
+        name: 'WebhookMonitor',
+        component: () => import('../components/views/WebhookMonitor.vue'),
+      },
     ],
   },
 ];

--- a/tau/core/views.py
+++ b/tau/core/views.py
@@ -22,7 +22,7 @@ import constance.settings
 from tau.twitch.models import TwitchAPIScope, TwitchEventSubSubscription
 from tau.users.models import User
 from .forms import ChannelNameForm, FirstRunForm
-from  .utils import log_request, check_access_token_expired, refresh_access_token
+from  .utils import cleanup_remote_webhooks, cleanup_webhooks, log_request, check_access_token_expired, refresh_access_token, teardown_all_acct_webhooks, teardown_webhooks
 from tau.twitch.models import TwitchHelixEndpoint
 
 @api_view(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])
@@ -207,6 +207,24 @@ def refresh_tau_token(request):
         token = Token.objects.create(user=request.user)
 
         return JsonResponse({'token': token.key})
+
+@api_view(['POST'])
+def reset_webhooks(request):
+    if not request.user.is_authenticated:
+        return JsonResponse({'error': 'You must be logged into access this endpoint.'})
+    data = request.data
+    if data['type'] == 'all':
+        teardown_all_acct_webhooks()
+    elif data['type'] == 'remote':
+        token = Token.objects.get(user=request.user)
+        cleanup_remote_webhooks()
+    elif data['type'] == 'broken':
+        token = Token.objects.get(user=request.user)
+        cleanup_webhooks()
+    else:
+        return JsonResponse({'webhooks_reset': False, 'error': 'Proper type not found.'})
+    config.FORCE_WEBHOOK_REFRESH = True
+    return JsonResponse({'webhooks_reset': True})
 
 def process_twitch_callback_view(request):
     port = os.environ.get('PORT', 8000)

--- a/tau/core/worker.py
+++ b/tau/core/worker.py
@@ -146,6 +146,12 @@ class Worker():
             if refresh_webhooks or refreshed_ngrok:
                 await database_sync_to_async(self.setup_webhooks)()
                 refresh_webhooks = False
+            
+            force_refresh_webhooks = await database_sync_to_async(self.lookup_setting)('FORCE_WEBHOOK_REFRESH')
+
+            if force_refresh_webhooks:
+                await database_sync_to_async(self.setup_webhooks)()
+                await database_sync_to_async(self.set_setting)('FORCE_WEBHOOK_REFRESH', False)
 
             await asyncio.sleep(self.wh_delay)
 

--- a/tau/urls.py
+++ b/tau/urls.py
@@ -41,7 +41,8 @@ from .core.views import (
     HeartbeatViewSet,
     ServiceStatusViewSet,
     helix_view,
-    TAUSettingsViewSet
+    TAUSettingsViewSet,
+    reset_webhooks
 )
 
 router = OptionalSlashRouter()
@@ -68,6 +69,7 @@ urlpatterns = [
     path('api/v1/tau-user-token/', get_tau_token),
     path('api/v1/tau-user-token/refresh/', refresh_tau_token),
     path('api/v1/public_url', get_public_url),
+    path('api/v1/reset-webhooks', reset_webhooks),
     path('api/twitch/helix/<path:helix_path>', helix_view),
     path('api/v1/', include(router.urls)),
     path('api-token-auth/', views.obtain_auth_token),


### PR DESCRIPTION
Adds a page the dashboard that allows the user to list any webhooks that Twitch has set up with the app token provided during setup, view their validity, and see if they are local to the current TAU install.   There are also buttons to reset all webhooks, any invalid webhooks, or any webhooks not local to the current TAU instance.