### PR TITLE
add more details to event titles

### DIFF
--- a/tau-dashboard/src/models/twitch-event.ts
+++ b/tau-dashboard/src/models/twitch-event.ts
@@ -15,13 +15,13 @@ export const eventTitleMap: { [key: string]: any } = {
   'channel-follow': (obj: any) => `${obj.event_data.user_name} followed`,
   'channel-channel_points_custom_reward_redemption-add': (obj: any) =>
     `${obj.event_data.user_name} redeemed ${obj.event_data.reward.title}`,
-  'stream-offline': (obj: any) => `${event_data.broadcaster_user_name} is offline`,
-  'stream-online': (obj: any) => `${event_data.broadcaster_user_name} is online`,
-  'channel-subscription-end': (obj: any) => `${event_data.user_name} stopped subscribing`,
-  'channel-subscribe': (obj: any) => `${event_data.user_name} subscribed`,
-  'channel-subscription-gift': (obj: any) => `${event_data.user_name} gifted ${event_data.total} subs`,
-  'channel-raid': (obj: any) => `${event_data.from_broadcaster_user_name} raided with ${event_data.viewers} viewers`,
-  'channel-channel_points_custom_reward_redemption-add': (obj: any) => `${event_data.user_name} redeemed ${event_data.reward.title}`,
+  'stream-offline': (obj: any) => `${obj.event_data.broadcaster_user_name} is offline`,
+  'stream-online': (obj: any) => `${obj.event_data.broadcaster_user_name} is online`,
+  'channel-subscription-end': (obj: any) => `${obj.event_data.user_name} stopped subscribing`,
+  'channel-subscribe': (obj: any) => `${obj.event_data.user_name} subscribed`,
+  'channel-subscription-gift': (obj: any) => `${obj.event_data.user_name} gifted ${obj.event_data.total} subs`,
+  'channel-raid': (obj: any) => `${obj.event_data.from_broadcaster_user_name} raided with ${obj.event_data.viewers} viewers`,
+  'channel-channel_points_custom_reward_redemption-add': (obj: any) => `${obj.event_data.user_name} redeemed ${obj.event_data.reward.title}`,
   default: (obj: any) =>
     `${obj.event_type.replaceAll('-', ' ').replaceAll('_', ' ')}`,
 };

--- a/tau-dashboard/src/models/twitch-event.ts
+++ b/tau-dashboard/src/models/twitch-event.ts
@@ -15,6 +15,13 @@ export const eventTitleMap: { [key: string]: any } = {
   'channel-follow': (obj: any) => `${obj.event_data.user_name} followed`,
   'channel-channel_points_custom_reward_redemption-add': (obj: any) =>
     `${obj.event_data.user_name} redeemed ${obj.event_data.reward.title}`,
+  'stream-offline': (obj: any) => `${event_data.broadcaster_user_name} is offline`,
+  'stream-online': (obj: any) => `${event_data.broadcaster_user_name} is online`,
+  'channel-subscription-end': (obj: any) => `${event_data.user_name} stopped subscribing`,
+  'channel-subscribe': (obj: any) => `${event_data.user_name} subscribed`,
+  'channel-subscription-gift': (obj: any) => `${event_data.user_name} gifted ${event_data.total} subs`,
+  'channel-raid': (obj: any) => `${event_data.from_broadcaster_user_name} raided with ${event_data.viewers} viewers`,
+  'channel-channel_points_custom_reward_redemption-add': (obj: any) => `${event_data.user_name} redeemed ${event_data.reward.title}`,
   default: (obj: any) =>
     `${obj.event_type.replaceAll('-', ' ').replaceAll('_', ' ')}`,
 };

--- a/tau-dashboard/src/models/twitch-event.ts
+++ b/tau-dashboard/src/models/twitch-event.ts
@@ -20,7 +20,7 @@ export const eventTitleMap: { [key: string]: any } = {
   'channel-subscription-end': (obj: any) => `${obj.event_data.user_name} stopped subscribing`,
   'channel-subscribe': (obj: any) => `${obj.event_data.user_name} subscribed`,
   'channel-subscription-gift': (obj: any) => `${obj.event_data.user_name} gifted ${obj.event_data.total} subs`,
-  'channel-raid': (obj: any) => `${obj.event_data.from_broadcaster_user_name} raided with ${obj.event_data.viewers} viewers`
+  'channel-raid': (obj: any) => `${obj.event_data.from_broadcaster_user_name} raided with ${obj.event_data.viewers} viewers`,
   default: (obj: any) =>
     `${obj.event_type.replaceAll('-', ' ').replaceAll('_', ' ')}`,
 };

--- a/tau-dashboard/src/models/twitch-event.ts
+++ b/tau-dashboard/src/models/twitch-event.ts
@@ -20,8 +20,7 @@ export const eventTitleMap: { [key: string]: any } = {
   'channel-subscription-end': (obj: any) => `${obj.event_data.user_name} stopped subscribing`,
   'channel-subscribe': (obj: any) => `${obj.event_data.user_name} subscribed`,
   'channel-subscription-gift': (obj: any) => `${obj.event_data.user_name} gifted ${obj.event_data.total} subs`,
-  'channel-raid': (obj: any) => `${obj.event_data.from_broadcaster_user_name} raided with ${obj.event_data.viewers} viewers`,
-  'channel-channel_points_custom_reward_redemption-add': (obj: any) => `${obj.event_data.user_name} redeemed ${obj.event_data.reward.title}`,
+  'channel-raid': (obj: any) => `${obj.event_data.from_broadcaster_user_name} raided with ${obj.event_data.viewers} viewers`
   default: (obj: any) =>
     `${obj.event_type.replaceAll('-', ' ').replaceAll('_', ' ')}`,
 };


### PR DESCRIPTION
This PR is to add more details in the title of the events that are shown in the Websocket Stream. Currently only some show more details directly in the title of the accordion element. Adding this will help reduce the need to expand the accordion element to see what event happened.

I generally will keep TAU up and monitor the Websocket Stream. This would be a nice addition to reduce the need to click on anything to understand what event happened.

Hope this helps and is found to be a useful addition 🙂👍