### PR TITLE
docker: use slim base images to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:16 as build-stage
+FROM node:16-slim as build-stage
 WORKDIR /app
 COPY ./tau-dashboard/package*.json ./
 RUN npm install
@@ -7,11 +7,12 @@ COPY ./tau-dashboard /app
 RUN npm run build
 
 # prododuction stage
-FROM python:3.8 as prod-stage
+FROM python:3.8-slim as prod-stage
 ENV PYTHONUNBUFFERED=1 PYTHONHASHSEED=random \
     PYTHONDONTWRITEBYTECODE=1 PIP_NO_CACHE_DIR=1
 
 # install supervisord (supervisor-stdout is not py3 compatible in pypi)
+RUN apt update && apt install -y git && rm -rf /var/lib/apt/lists/*
 RUN pip install supervisor git+https://github.com/coderanger/supervisor-stdout
 
 # Sets work directory to /code


### PR DESCRIPTION
There's probably still a lot of improvements to make here, but this is a pretty big size reduction to begin with

| Base Image  | Built Image Size |
| ------------- | ------------- |
| python:3.8  | 1.11 GB  |
| python:3.8-slim  | 410 MB  |

If we want to take things further, here's a breakdown of where the bytes come from:
```
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
8c96c42b044d   8 minutes ago    CMD ["/bin/sh" "-c" "bash -c \"./scripts/sta…   0B        buildkit.dockerfile.v0
<missing>      8 minutes ago    COPY /app/dist /code/tau-dashboard/dist # bu…   4.75MB    buildkit.dockerfile.v0
<missing>      8 minutes ago    COPY . /code # buildkit                         1.86MB    buildkit.dockerfile.v0
<missing>      31 minutes ago   COPY supervisord.conf /etc/supervisord.conf …   744B      buildkit.dockerfile.v0
<missing>      31 minutes ago   RUN /bin/sh -c pip install -r requirements.t…   194MB     buildkit.dockerfile.v0
<missing>      32 minutes ago   COPY requirements.txt . # buildkit              1.14kB    buildkit.dockerfile.v0
<missing>      32 minutes ago   WORKDIR /code                                   0B        buildkit.dockerfile.v0
<missing>      32 minutes ago   RUN /bin/sh -c pip install supervisor git+ht…   2.76MB    buildkit.dockerfile.v0
<missing>      32 minutes ago   RUN /bin/sh -c apt update && apt install -y …   82.6MB    buildkit.dockerfile.v0
<missing>      32 minutes ago   ENV PYTHONUNBUFFERED=1 PYTHONHASHSEED=random…   0B        buildkit.dockerfile.v0
<missing>      2 days ago       /bin/sh -c #(nop)  CMD ["python3"]              0B
<missing>      2 days ago       /bin/sh -c set -eux;   savedAptMark="$(apt-m…   11.4MB
<missing>      2 days ago       /bin/sh -c #(nop)  ENV PYTHON_GET_PIP_SHA256…   0B
<missing>      2 days ago       /bin/sh -c #(nop)  ENV PYTHON_GET_PIP_URL=ht…   0B
<missing>      2 days ago       /bin/sh -c #(nop)  ENV PYTHON_SETUPTOOLS_VER…   0B
<missing>      2 days ago       /bin/sh -c #(nop)  ENV PYTHON_PIP_VERSION=22…   0B
<missing>      2 days ago       /bin/sh -c set -eux;  for src in idle3 pydoc…   32B
<missing>      2 days ago       /bin/sh -c set -eux;   savedAptMark="$(apt-m…   28.5MB
<missing>      2 days ago       /bin/sh -c #(nop)  ENV PYTHON_VERSION=3.8.16    0B
<missing>      2 days ago       /bin/sh -c #(nop)  ENV GPG_KEY=E3FF2839C048B…   0B
<missing>      2 days ago       /bin/sh -c set -eux;  apt-get update;  apt-g…   3.11MB
<missing>      2 days ago       /bin/sh -c #(nop)  ENV LANG=C.UTF-8             0B
<missing>      2 days ago       /bin/sh -c #(nop)  ENV PATH=/usr/local/bin:/…   0B
<missing>      2 days ago       /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      2 days ago       /bin/sh -c #(nop) ADD file:493a5b0c8d2d63a13…   80.5MB
```

We can see from the logs that this line is adding `194MB` to the image:
https://github.com/Team-TAU/tau/blob/818fd8750a4913ee45b687b640145b8cefe1bc8d/Dockerfile#L22

I'm not too familiar with the dependencies of the project, so I'm not sure which ones might be adding this;

Also, the fact that we need to install git in order to install the supervisor adds an additional `82.6MB` to the image.

The lower bound using `python:3.8-slim` is around `130mb` - if we want to go any smaller, we'd need to switch to alpine.