### PR TITLE
create github action to build docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,21 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - uses: docker/build-push-action@v4.0.0
+      with:
+        tags: ghcr.io/Team-TAU/tau
+        push: true


### PR DESCRIPTION
This is a simple workflow to build and push the docker image to https://ghcr.io (GitHub's docker container registry)

This might require changing this setting for workflows in the repository settings:
![image](https://user-images.githubusercontent.com/4583705/222845346-cb433fdb-508e-4189-b35f-891f5bfcd106.png)
