### PR TITLE
update follows eventsub to v2

### DIFF
--- a/eventsub_subscriptions.json
+++ b/eventsub_subscriptions.json
@@ -74,9 +74,9 @@
   {
     "subscription_type": "Channel Follow",
     "name": "channel.follow",
-    "version": "1",
+    "version": "2",
     "description": "A specified channel receives a follow.",
-    "scope_required": null,
+    "scope_required": "moderator:read:followers",
     "event_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": null,
@@ -133,9 +133,13 @@
         "broadcaster_user_id": {
           "description": "The broadcaster user ID for the channel you want to get follow notifications for.",
           "type": "string"
+        },
+        "moderator_user_id": {
+          "description": "The ID of the moderator of the channel you want to get follow notifications for. If you have authorization from the broadcaster rather than a moderator, specify the broadcaster’s user ID here.",
+          "type": "string"
         }
       },
-      "required": ["broadcaster_user_id"]
+      "required": ["broadcaster_user_id", "moderator_user_id"]
     }
   },
   {


### PR DESCRIPTION
Twitch recently made some changes to the `channel.follow` subscription as documented here: https://dev.twitch.tv/docs/change-log/

they removed the v1 of the subscription and force you to use v2 instead

I'm not sure if there's anything else that needs to be changed; I'm running this change on my personal instance, and it seems to have resolved the problem